### PR TITLE
Implement natural language agent builder service

### DIFF
--- a/server/src/config/permissionLoader.ts
+++ b/server/src/config/permissionLoader.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+export type PermissionMap = Record<string, string[]>;
+
+let cachedPermissions: PermissionMap | null = null;
+
+function parseSimpleYaml(content: string): PermissionMap {
+  const lines = content.split(/\r?\n/);
+  const result: PermissionMap = {};
+  let currentKey: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line || line.trim().startsWith('#')) {
+      continue;
+    }
+
+    if (!line.startsWith('-') && line.includes(':')) {
+      const [key] = line.split(':');
+      currentKey = key.trim();
+      if (!result[currentKey]) {
+        result[currentKey] = [];
+      }
+      continue;
+    }
+
+    if (line.trimStart().startsWith('-')) {
+      if (!currentKey) {
+        continue;
+      }
+      const value = line.replace(/^-\s*/, '').trim();
+      if (value) {
+        result[currentKey].push(value);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function loadPermissionMap(): PermissionMap {
+  if (cachedPermissions) {
+    return cachedPermissions;
+  }
+
+  const filePath = fileURLToPath(new URL('./permissions.yaml', import.meta.url));
+  const content = readFileSync(filePath, 'utf-8');
+  cachedPermissions = parseSimpleYaml(content);
+  return cachedPermissions;
+}

--- a/server/src/config/permissions.yaml
+++ b/server/src/config/permissions.yaml
@@ -1,0 +1,27 @@
+browser:
+  - fetch
+  - analyze
+  - summarize
+api:
+  - fetch
+  - analyze
+email:
+  - communicate
+  - notify
+scheduler:
+  - schedule
+  - automate
+notifier:
+  - notify
+  - alert
+code_executor:
+  - run_code
+  - analyze
+memory:
+  - remember
+  - retrieve
+summarizer:
+  - summarize
+llm:
+  - analyze
+  - synthesize

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { initDb } from './db.js';
 import agentsRoute from './routes/agents.js';
 import tasksRoute from './routes/tasks.js';
 import commandsRoute from './routes/commands.js';
+import agentBuilderRoute from './routes/agentBuilder.js';
 import { coordinator } from './core/Coordinator.js';
 
 async function bootstrap() {
@@ -21,6 +22,7 @@ async function bootstrap() {
   app.use('/agents', agentsRoute);
   app.use('/tasks', tasksRoute);
   app.use('/commands', commandsRoute);
+  app.use('/agent-builder', agentBuilderRoute);
 
   app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
     console.error(err);

--- a/server/src/routes/agentBuilder.ts
+++ b/server/src/routes/agentBuilder.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { naturalLanguageAgentBuilder } from '../services/NaturalLanguageAgentBuilder.js';
+
+const router = Router();
+
+const buildSchema = z.object({
+  promptText: z.string().min(1),
+  options: z
+    .object({
+      persist: z.boolean().optional(),
+      spawn: z.boolean().optional(),
+      creator: z.string().optional()
+    })
+    .optional()
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = buildSchema.parse(req.body);
+    const result = await naturalLanguageAgentBuilder.buildAgent(payload.promptText, payload.options ?? {});
+    res.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/spec', async (req, res, next) => {
+  try {
+    const payload = buildSchema.pick({ promptText: true, options: true }).parse(req.body);
+    const creator = payload.options?.creator ?? 'anonymous';
+    const spec = naturalLanguageAgentBuilder.buildSpec(payload.promptText, creator);
+    res.json({ spec });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/services/AgentRunner.ts
+++ b/server/src/services/AgentRunner.ts
@@ -1,0 +1,16 @@
+import type { AgentSpec } from './NaturalLanguageAgentBuilder.js';
+
+export interface RunnerLog {
+  timestamp: string;
+  message: string;
+}
+
+export class AgentRunner {
+  launch(spec: AgentSpec): RunnerLog {
+    const timestamp = new Date().toISOString();
+    return {
+      timestamp,
+      message: `Agent "${spec.name}" scheduled for execution inside sandbox with timeout ${spec.securityProfile.executionTimeout}s.`
+    };
+  }
+}

--- a/server/src/services/NaturalLanguageAgentBuilder.ts
+++ b/server/src/services/NaturalLanguageAgentBuilder.ts
@@ -1,0 +1,294 @@
+import { loadPermissionMap } from '../config/permissionLoader.js';
+import { SandboxManager, type SpawnResult } from './SandboxManager.js';
+
+const permissionMap = loadPermissionMap();
+
+export interface AgentSpec {
+  name: string;
+  description: string;
+  goals: string[];
+  capabilities: {
+    tools: string[];
+    memory: boolean;
+    autonomy_level: 'manual' | 'semi' | 'autonomous';
+    execution_interval: string;
+  };
+  model: string;
+  securityProfile: {
+    sandbox: boolean;
+    network: {
+      allowInternet: boolean;
+      domainsAllowed: string[];
+    };
+    filesystem: {
+      read: string[];
+      write: string[];
+    };
+    permissions: string[];
+    executionTimeout: number;
+  };
+  creator: string;
+  created_at: string;
+}
+
+export interface BuildAgentOptions {
+  persist?: boolean;
+  spawn?: boolean;
+  creator?: string;
+}
+
+export interface BuildAgentResult {
+  spec: AgentSpec;
+  savedAgent?: unknown;
+  spawnResult?: SpawnResult | null;
+}
+
+const TOOL_KEYWORDS: Record<string, RegExp[]> = {
+  browser: [/(\b|\s)(fetch|scrape|browse|monitor|read|check|track|scan|research)(\b|\s)/i, /news/i, /web/i],
+  api: [/api/i, /endpoint/i, /integrate/i],
+  email: [/email/i, /mail\b/i, /inbox/i, /send\s+me/i],
+  scheduler: [/daily/i, /weekly/i, /every\s+(morning|day|week|hour|month)/i, /schedule/i],
+  notifier: [/notify/i, /alert/i, /remind/i],
+  summarizer: [/summary/i, /summari[sz]e/i, /digest/i],
+  code_executor: [/run\s+code/i, /execute\s+script/i, /simulation/i],
+  memory: [/remember/i, /log/i, /history/i],
+  llm: [/write/i, /draft/i, /analy[sz]e/i, /generate/i]
+};
+
+const DOMAIN_MAPPINGS: { keywords: RegExp[]; domains: string[] }[] = [
+  { keywords: [/crypto/i, /bitcoin/i, /ethereum/i, /token/i], domains: ['api.coingecko.com'] },
+  { keywords: [/stock/i, /market/i, /finance/i, /equity/i], domains: ['finnhub.io', 'alphavantage.co'] },
+  { keywords: [/news/i, /headline/i, /press/i], domains: ['newsapi.org'] },
+  { keywords: [/weather/i, /forecast/i, /temperature/i], domains: ['api.openweathermap.org'] },
+  { keywords: [/github/i, /repository/i], domains: ['api.github.com'] },
+  { keywords: [/tweet/i, /twitter/i, /x\.com/i], domains: ['api.twitter.com'] }
+];
+
+const INTERNET_CUES = [/internet/i, /online/i, /fetch/i, /browser/i, /api/i, /scrape/i, /news/i, /monitor/i];
+
+const SUMMARY_CUES = [/summary/i, /summari[sz]e/i, /digest/i];
+
+function dedupe<T>(items: T[]): T[] {
+  return Array.from(new Set(items));
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function inferName(prompt: string): string {
+  const segments = prompt
+    .replace(/[.!?]/g, '')
+    .split(/(?:make|build|create|need|want|design|develop)\s+me\s+an?\s+agent\s+that/i);
+  const relevant = segments.length > 1 ? segments[1] : prompt;
+  const keywords = ['news', 'crypto', 'research', 'email', 'weather', 'insight', 'market'];
+  for (const keyword of keywords) {
+    if (new RegExp(keyword, 'i').test(prompt)) {
+      return titleCase(`${keyword} assistant`).replace(/\bAssistant\b/i, 'Assistant');
+    }
+  }
+  const truncated = relevant.trim().split(/[,;:.]/)[0];
+  const words = truncated.split(/\s+/).slice(0, 3);
+  if (words.length > 0) {
+    return titleCase(`${words.join(' ')} Agent`).trim();
+  }
+  return 'Adaptive Agent';
+}
+
+function summarizePrompt(prompt: string): string {
+  const trimmed = prompt.trim();
+  if (trimmed.length <= 140) {
+    return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+  }
+  return `${trimmed.slice(0, 137)}...`;
+}
+
+function extractGoals(prompt: string): string[] {
+  const normalized = prompt.replace(/[.!?]/g, '.');
+  const parts = normalized
+    .split(/\b(?:and then|then|and|so that|to)\b/i)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const goals = new Set<string>();
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (/(fetch|get|collect|pull)/.test(lower) && /(news|data|updates|prices|information)/.test(lower)) {
+      goals.add('Fetch relevant data from trusted sources');
+    }
+    if (/(summari|digest|condense|report)/.test(lower)) {
+      goals.add('Summarize findings into concise reports');
+    }
+    if (/(email|send|notify|alert)/.test(lower)) {
+      goals.add('Deliver notifications or summaries to stakeholders');
+    }
+    if (/(analy|insight|interpret)/.test(lower)) {
+      goals.add('Analyze data to surface actionable insights');
+    }
+    if (/(monitor|track|watch)/.test(lower)) {
+      goals.add('Continuously monitor sources for new information');
+    }
+    if (/(schedule|daily|weekly|morning|evening)/.test(lower)) {
+      goals.add('Run on a recurring schedule without manual intervention');
+    }
+  }
+
+  if (goals.size === 0) {
+    goals.add(prompt.trim());
+  }
+
+  return Array.from(goals);
+}
+
+function detectTools(prompt: string): string[] {
+  const tools: string[] = [];
+  for (const [tool, patterns] of Object.entries(TOOL_KEYWORDS)) {
+    if (patterns.some((pattern) => pattern.test(prompt))) {
+      tools.push(tool);
+    }
+  }
+  if (!tools.includes('llm')) {
+    tools.push('llm');
+  }
+  if (SUMMARY_CUES.some((pattern) => pattern.test(prompt)) && !tools.includes('summarizer')) {
+    tools.push('summarizer');
+  }
+  return dedupe(tools);
+}
+
+function detectAutonomy(prompt: string): 'manual' | 'semi' | 'autonomous' {
+  if (/(automatic|automatically|without\s+me|hands?-?free|self\b)/i.test(prompt)) {
+    return 'autonomous';
+  }
+  if (/(assist|help|support)/i.test(prompt)) {
+    return 'semi';
+  }
+  return 'semi';
+}
+
+function detectInterval(prompt: string): string {
+  if (/every\s+hour|hourly/i.test(prompt)) {
+    return 'hourly';
+  }
+  if (/daily|every\s+(day|morning|evening)/i.test(prompt)) {
+    return 'daily';
+  }
+  if (/weekly|every\s+week/i.test(prompt)) {
+    return 'weekly';
+  }
+  if (/monthly|every\s+month/i.test(prompt)) {
+    return 'monthly';
+  }
+  if (/real\s*-?time|continuous|ongoing/i.test(prompt)) {
+    return 'continuous';
+  }
+  return 'on_demand';
+}
+
+function detectDomains(prompt: string): string[] {
+  const domains = new Set<string>();
+  for (const mapping of DOMAIN_MAPPINGS) {
+    if (mapping.keywords.some((regex) => regex.test(prompt))) {
+      mapping.domains.forEach((domain) => domains.add(domain));
+    }
+  }
+  if (domains.size === 0 && INTERNET_CUES.some((regex) => regex.test(prompt))) {
+    domains.add('newsapi.org');
+  }
+  return Array.from(domains);
+}
+
+function detectPermissions(tools: string[], prompt: string): string[] {
+  const permissions = new Set<string>();
+  tools.forEach((tool) => {
+    const entries = permissionMap[tool];
+    if (entries) {
+      entries.forEach((permission) => permissions.add(permission));
+    }
+  });
+  if (SUMMARY_CUES.some((pattern) => pattern.test(prompt))) {
+    permissions.add('summarize');
+  }
+  if (permissions.size === 0) {
+    ['analyze'].forEach((permission) => permissions.add(permission));
+  }
+  return Array.from(permissions);
+}
+
+function detectMemory(prompt: string): boolean {
+  return /(remember|history|log|past|previous|context|record)/i.test(prompt) || SUMMARY_CUES.some((pattern) => pattern.test(prompt));
+}
+
+function shouldAllowInternet(prompt: string): boolean {
+  return INTERNET_CUES.some((pattern) => pattern.test(prompt));
+}
+
+export class NaturalLanguageAgentBuilder {
+  constructor(private readonly sandboxManager = new SandboxManager()) {}
+
+  buildSpec(promptText: string, creator = 'anonymous'): AgentSpec {
+    const name = inferName(promptText);
+    const description = summarizePrompt(promptText);
+    const goals = extractGoals(promptText);
+    const tools = detectTools(promptText);
+    const allowInternet = shouldAllowInternet(promptText);
+    const domains = allowInternet ? detectDomains(promptText) : [];
+    const permissions = detectPermissions(tools, promptText);
+    const execution_interval = detectInterval(promptText);
+    const memory = detectMemory(promptText);
+    const autonomy_level = detectAutonomy(promptText);
+
+    const spec: AgentSpec = {
+      name,
+      description,
+      goals,
+      capabilities: {
+        tools,
+        memory,
+        autonomy_level,
+        execution_interval
+      },
+      model: 'gpt-5',
+      securityProfile: {
+        sandbox: true,
+        network: {
+          allowInternet,
+          domainsAllowed: allowInternet ? domains : []
+        },
+        filesystem: {
+          read: ['workspace/tmp'],
+          write: ['workspace/output']
+        },
+        permissions,
+        executionTimeout: 300
+      },
+      creator,
+      created_at: new Date().toISOString()
+    };
+
+    return spec;
+  }
+
+  async buildAgent(promptText: string, options: BuildAgentOptions = {}): Promise<BuildAgentResult> {
+    const creator = options.creator ?? 'anonymous';
+    const spec = this.buildSpec(promptText, creator);
+
+    let savedAgent: unknown | undefined;
+    if (options.persist ?? true) {
+      savedAgent = await this.sandboxManager.saveAgent(spec);
+    }
+
+    let spawnResult: SpawnResult | null = null;
+    if (options.spawn) {
+      spawnResult = await this.sandboxManager.spawnAgent(spec);
+    }
+
+    return { spec, savedAgent, spawnResult };
+  }
+}
+
+export const naturalLanguageAgentBuilder = new NaturalLanguageAgentBuilder();

--- a/server/src/services/NetworkProxy.ts
+++ b/server/src/services/NetworkProxy.ts
@@ -1,0 +1,27 @@
+export interface NetworkSecurityConfig {
+  allowInternet: boolean;
+  domainsAllowed: string[];
+}
+
+export interface NetworkProxyLog {
+  timestamp: string;
+  message: string;
+}
+
+export class NetworkProxy {
+  configure(config: NetworkSecurityConfig): NetworkProxyLog {
+    const timestamp = new Date().toISOString();
+    if (!config.allowInternet) {
+      return {
+        timestamp,
+        message: 'Network proxy configured for offline execution. External requests are blocked.'
+      };
+    }
+
+    const domains = config.domainsAllowed.length > 0 ? config.domainsAllowed.join(', ') : 'no domains specified';
+    return {
+      timestamp,
+      message: `Network proxy enabled with internet access limited to: ${domains}.`
+    };
+  }
+}

--- a/server/src/services/SandboxManager.ts
+++ b/server/src/services/SandboxManager.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'crypto';
+import { agentManager } from '../core/AgentManager.js';
+import type { AgentSpec } from './NaturalLanguageAgentBuilder.js';
+import { AgentRunner } from './AgentRunner.js';
+import { NetworkProxy, type NetworkProxyLog } from './NetworkProxy.js';
+
+export interface SandboxLaunchLog {
+  timestamp: string;
+  message: string;
+}
+
+export interface SpawnResult {
+  sandboxId: string;
+  logs: SandboxLaunchLog[];
+}
+
+export class SandboxManager {
+  constructor(
+    private readonly agentRunner = new AgentRunner(),
+    private readonly networkProxy = new NetworkProxy()
+  ) {}
+
+  async saveAgent(agentSpec: AgentSpec) {
+    const record = await agentManager.createAgent({
+      name: agentSpec.name,
+      role: agentSpec.description,
+      tools: agentSpec.capabilities.tools.reduce<Record<string, boolean>>((acc, tool) => {
+        acc[tool] = true;
+        return acc;
+      }, {}),
+      objectives: agentSpec.goals,
+      memory_context: agentSpec.capabilities.memory ? 'Long-term memory enabled' : ''
+    });
+
+    return record;
+  }
+
+  async spawnAgent(agentSpec: AgentSpec): Promise<SpawnResult> {
+    const sandboxId = randomUUID();
+    const logs: SandboxLaunchLog[] = [];
+
+    const networkLog: NetworkProxyLog = this.networkProxy.configure(agentSpec.securityProfile.network);
+    logs.push(networkLog);
+
+    const runnerLog = this.agentRunner.launch(agentSpec);
+    logs.push(runnerLog);
+
+    logs.push({
+      timestamp: new Date().toISOString(),
+      message: `Sandbox ${sandboxId} initialized with filesystem policy read: ${agentSpec.securityProfile.filesystem.read.join(', ') || 'none'}, write: ${agentSpec.securityProfile.filesystem.write.join(', ') || 'none'}.`
+    });
+
+    return { sandboxId, logs };
+  }
+}


### PR DESCRIPTION
## Summary
- add a natural language agent builder service that converts prompts into structured agent specs with sandboxed security profiles
- introduce sandbox, network proxy, and runner helpers plus permission mapping config for controlled tool access
- expose REST endpoints for building agent specs and optional spawning via the new agent builder route

## Testing
- npm --prefix server run build

------
https://chatgpt.com/codex/tasks/task_e_68e6319f89e48326b9b2c7a42dd7c29f