### PR TITLE
Fix permission asset packaging and add natural language agent creation UI

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { CommandResponse } from '../types';
+import type { BuildAgentResult, CommandResponse, GeneratedAgentSpec } from '../types';
 
 const API_BASE = process.env.VITE_API_BASE || process.env.REACT_APP_API_BASE || 'http://localhost:4000';
 
@@ -53,6 +53,23 @@ export const api = {
     return request<CommandResponse>('/commands', {
       method: 'POST',
       body: JSON.stringify({ input })
+    });
+  },
+  async buildAgentFromPrompt(payload: {
+    promptText: string;
+    persist?: boolean;
+    spawn?: boolean;
+    creator?: string;
+  }) {
+    return request<BuildAgentResult>('/agent-builder', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+  },
+  async previewAgentSpec(payload: { promptText: string; creator?: string }) {
+    return request<{ spec: GeneratedAgentSpec }>('/agent-builder/spec', {
+      method: 'POST',
+      body: JSON.stringify(payload)
     });
   }
 };

--- a/frontend/src/components/CreateAgentModal.tsx
+++ b/frontend/src/components/CreateAgentModal.tsx
@@ -1,32 +1,63 @@
 import { Dialog, Transition } from '@headlessui/react';
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
+import type { BuildAgentResult } from '../types';
 
 const roleOptions = ['Finance', 'Outreach', 'Research', 'Operations', 'FounderCore'];
 const toolOptions = ['Gmail', 'Docs', 'CRM', 'Notion', 'Slack'];
 
+type Mode = 'natural' | 'manual';
+
 interface CreateAgentModalProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (payload: { name: string; role: string; tools: Record<string, boolean>; objectives: string[] }) => Promise<void>;
+  onCreateManual: (payload: { name: string; role: string; tools: Record<string, boolean>; objectives: string[] }) => Promise<void>;
+  onGenerateFromPrompt: (payload: { promptText: string; persist?: boolean; spawn?: boolean }) => Promise<BuildAgentResult>;
 }
 
-export function CreateAgentModal({ open, onClose, onSubmit }: CreateAgentModalProps) {
+export function CreateAgentModal({ open, onClose, onCreateManual, onGenerateFromPrompt }: CreateAgentModalProps) {
+  const [mode, setMode] = useState<Mode>('natural');
   const [name, setName] = useState('');
   const [role, setRole] = useState(roleOptions[0]);
   const [objectives, setObjectives] = useState('');
   const [selectedTools, setSelectedTools] = useState<Record<string, boolean>>({});
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [manualSubmitting, setManualSubmitting] = useState(false);
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  const [promptText, setPromptText] = useState('');
+  const [spawnRequested, setSpawnRequested] = useState(false);
+  const [naturalSubmitting, setNaturalSubmitting] = useState(false);
+  const [naturalError, setNaturalError] = useState<string | null>(null);
+  const [generatedResult, setGeneratedResult] = useState<BuildAgentResult | null>(null);
 
   const toggleTool = (tool: string) => {
     setSelectedTools((prev) => ({ ...prev, [tool]: !prev[tool] }));
   };
 
-  const handleSubmit = async () => {
-    setError(null);
-    setSubmitting(true);
+  const resetState = () => {
+    setMode('natural');
+    setName('');
+    setRole(roleOptions[0]);
+    setObjectives('');
+    setSelectedTools({});
+    setManualSubmitting(false);
+    setManualError(null);
+    setPromptText('');
+    setSpawnRequested(false);
+    setNaturalSubmitting(false);
+    setNaturalError(null);
+    setGeneratedResult(null);
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleSubmitManual = async () => {
+    setManualError(null);
+    setManualSubmitting(true);
     try {
-      await onSubmit({
+      await onCreateManual({
         name,
         role,
         tools: selectedTools,
@@ -35,20 +66,97 @@ export function CreateAgentModal({ open, onClose, onSubmit }: CreateAgentModalPr
           .map((line) => line.trim())
           .filter(Boolean)
       });
-      setName('');
-      setObjectives('');
-      setSelectedTools({});
+      resetState();
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create agent');
+      setManualError(err instanceof Error ? err.message : 'Failed to create agent');
     } finally {
-      setSubmitting(false);
+      setManualSubmitting(false);
     }
   };
 
+  const handleGenerate = async () => {
+    setNaturalError(null);
+    setNaturalSubmitting(true);
+    try {
+      const result = await onGenerateFromPrompt({
+        promptText,
+        spawn: spawnRequested || undefined,
+        persist: true
+      });
+      setGeneratedResult(result);
+    } catch (err) {
+      setNaturalError(err instanceof Error ? err.message : 'Failed to generate agent');
+      setGeneratedResult(null);
+    } finally {
+      setNaturalSubmitting(false);
+    }
+  };
+
+  const generatedSpec = generatedResult?.spec;
+
+  const renderSecurityProfile = useMemo(() => {
+    if (!generatedSpec) {
+      return null;
+    }
+
+    const { securityProfile } = generatedSpec;
+    return (
+      <div className="space-y-2 bg-slate-900/60 border border-slate-700 rounded-xl p-4 text-sm">
+        <h4 className="text-slate-200 font-semibold">Security Profile</h4>
+        <div className="text-slate-300">
+          <p>
+            Sandbox: <span className="text-emerald-300">{securityProfile.sandbox ? 'Enabled' : 'Disabled'}</span>
+          </p>
+          <p>
+            Internet Access:{' '}
+            <span className={securityProfile.network.allowInternet ? 'text-emerald-300' : 'text-slate-300'}>
+              {securityProfile.network.allowInternet ? 'Allowed' : 'Disabled'}
+            </span>
+          </p>
+          {securityProfile.network.allowInternet && securityProfile.network.domainsAllowed.length > 0 && (
+            <p>
+              Domains: <span className="text-slate-200">{securityProfile.network.domainsAllowed.join(', ')}</span>
+            </p>
+          )}
+          <p>
+            Filesystem Read: <span className="text-slate-200">{securityProfile.filesystem.read.join(', ') || 'None'}</span>
+          </p>
+          <p>
+            Filesystem Write: <span className="text-slate-200">{securityProfile.filesystem.write.join(', ') || 'None'}</span>
+          </p>
+          <p>
+            Permissions: <span className="text-slate-200">{securityProfile.permissions.join(', ') || 'None'}</span>
+          </p>
+          <p>Timeout: {securityProfile.executionTimeout}s</p>
+        </div>
+      </div>
+    );
+  }, [generatedSpec]);
+
+  const renderSpawnLogs = useMemo(() => {
+    if (!generatedResult?.spawnResult?.logs?.length) {
+      return null;
+    }
+
+    return (
+      <div className="space-y-2 bg-slate-900/60 border border-slate-700 rounded-xl p-4 text-sm">
+        <h4 className="text-slate-200 font-semibold">Sandbox Launch</h4>
+        <p className="text-slate-300">Sandbox ID: {generatedResult.spawnResult.sandboxId}</p>
+        <ul className="space-y-1 text-slate-300">
+          {generatedResult.spawnResult.logs.map((log) => (
+            <li key={`${log.timestamp}-${log.message}`} className="text-xs">
+              <span className="text-slate-500">[{new Date(log.timestamp).toLocaleTimeString()}]</span> {log.message}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }, [generatedResult]);
+
   return (
     <Transition appear show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={onClose}>
+      <Dialog as="div" className="relative z-10" onClose={handleClose}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -72,82 +180,203 @@ export function CreateAgentModal({ open, onClose, onSubmit }: CreateAgentModalPr
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-2xl bg-slate-900 p-6 text-left align-middle shadow-xl border border-slate-700">
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-slate-900 p-6 text-left align-middle shadow-xl border border-slate-700">
                 <Dialog.Title className="text-lg font-medium text-white">Create Agent</Dialog.Title>
-                <p className="text-sm text-slate-400 mb-4">Configure an agent with tools and objectives.</p>
+                <p className="text-sm text-slate-400 mb-4">
+                  Generate a secure agent from natural language or configure one manually.
+                </p>
 
-                <div className="space-y-4">
-                  <div>
-                    <label className="block text-sm text-slate-300">Name</label>
-                    <input
-                      type="text"
-                      value={name}
-                      onChange={(event) => setName(event.target.value)}
-                      className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
-                    />
+                <div className="flex gap-2 mb-4 text-sm">
+                  <button
+                    type="button"
+                    onClick={() => setMode('natural')}
+                    className={`px-3 py-1.5 rounded-lg border ${
+                      mode === 'natural'
+                        ? 'bg-emerald-500/20 border-emerald-500/40 text-emerald-200'
+                        : 'bg-slate-800/60 border-slate-600 text-slate-300'
+                    }`}
+                  >
+                    Natural Language
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMode('manual')}
+                    className={`px-3 py-1.5 rounded-lg border ${
+                      mode === 'manual'
+                        ? 'bg-emerald-500/20 border-emerald-500/40 text-emerald-200'
+                        : 'bg-slate-800/60 border-slate-600 text-slate-300'
+                    }`}
+                  >
+                    Manual
+                  </button>
+                </div>
+
+                {mode === 'natural' ? (
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm text-slate-300">Describe the agent you need</label>
+                      <textarea
+                        rows={5}
+                        value={promptText}
+                        onChange={(event) => setPromptText(event.target.value)}
+                        placeholder="e.g. Create an agent that monitors crypto prices and emails me a morning summary."
+                        className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
+                      />
+                    </div>
+
+                    <label className="flex items-center gap-2 text-sm text-slate-300">
+                      <input
+                        type="checkbox"
+                        checked={spawnRequested}
+                        onChange={(event) => setSpawnRequested(event.target.checked)}
+                        className="h-4 w-4 rounded border-slate-600 bg-slate-800"
+                      />
+                      Immediately spawn this agent in a sandbox after creation
+                    </label>
+
+                    {naturalError && <p className="text-sm text-red-300">{naturalError}</p>}
+
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        className="px-4 py-2 text-sm rounded-lg border border-slate-600 text-slate-200 hover:bg-slate-700/60"
+                        onClick={handleClose}
+                      >
+                        Close
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleGenerate}
+                        disabled={naturalSubmitting || !promptText.trim()}
+                        className="px-4 py-2 text-sm rounded-lg border border-emerald-500/40 bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30 disabled:opacity-50"
+                      >
+                        {naturalSubmitting ? 'Generating…' : 'Generate Agent'}
+                      </button>
+                    </div>
+
+                    {generatedSpec && (
+                      <div className="space-y-4 border-t border-slate-700 pt-4">
+                        <div>
+                          <h3 className="text-base font-semibold text-white">Generated Spec</h3>
+                          <p className="text-sm text-slate-300">{generatedSpec.description}</p>
+                        </div>
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-semibold text-slate-200">Goals</h4>
+                            <ul className="list-disc list-inside text-sm text-slate-300 space-y-1">
+                              {generatedSpec.goals.map((goal) => (
+                                <li key={goal}>{goal}</li>
+                              ))}
+                            </ul>
+                          </div>
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-semibold text-slate-200">Capabilities</h4>
+                            <p className="text-sm text-slate-300">
+                              Tools: <span className="text-slate-100">{generatedSpec.capabilities.tools.join(', ')}</span>
+                            </p>
+                            <p className="text-sm text-slate-300">
+                              Autonomy: <span className="text-slate-100">{generatedSpec.capabilities.autonomy_level}</span>
+                            </p>
+                            <p className="text-sm text-slate-300">
+                              Memory: <span className="text-slate-100">{generatedSpec.capabilities.memory ? 'Enabled' : 'Disabled'}</span>
+                            </p>
+                            <p className="text-sm text-slate-300">
+                              Cadence: <span className="text-slate-100">{generatedSpec.capabilities.execution_interval}</span>
+                            </p>
+                          </div>
+                        </div>
+
+                        {renderSecurityProfile}
+
+                        {generatedResult?.savedAgent && (
+                          <div className="space-y-1 text-sm text-slate-300 bg-slate-900/60 border border-slate-700 rounded-xl p-4">
+                            <h4 className="text-slate-200 font-semibold">Agent Saved</h4>
+                            <p>
+                              {generatedResult.savedAgent.name} created with ID{' '}
+                              <span className="text-slate-100">{generatedResult.savedAgent.id}</span>.
+                            </p>
+                          </div>
+                        )}
+
+                        {renderSpawnLogs}
+                      </div>
+                    )}
                   </div>
-                  <div>
-                    <label className="block text-sm text-slate-300">Role</label>
-                    <select
-                      value={role}
-                      onChange={(event) => setRole(event.target.value)}
-                      className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
-                    >
-                      {roleOptions.map((option) => (
-                        <option key={option}>{option}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm text-slate-300">Tools</label>
-                    <div className="flex flex-wrap gap-2 mt-2">
-                      {toolOptions.map((tool) => (
-                        <button
-                          type="button"
-                          key={tool}
-                          onClick={() => toggleTool(tool)}
-                          className={`px-3 py-1.5 rounded-lg border text-sm ${
-                            selectedTools[tool]
-                              ? 'bg-emerald-500/20 border-emerald-400/40 text-emerald-200'
-                              : 'bg-slate-800/60 border-slate-600 text-slate-300'
-                          }`}
-                        >
-                          {tool}
-                        </button>
-                      ))}
+                ) : (
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm text-slate-300">Name</label>
+                      <input
+                        type="text"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm text-slate-300">Role</label>
+                      <select
+                        value={role}
+                        onChange={(event) => setRole(event.target.value)}
+                        className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
+                      >
+                        {roleOptions.map((option) => (
+                          <option key={option}>{option}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-sm text-slate-300">Tools</label>
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {toolOptions.map((tool) => (
+                          <button
+                            type="button"
+                            key={tool}
+                            onClick={() => toggleTool(tool)}
+                            className={`px-3 py-1.5 rounded-lg border text-sm ${
+                              selectedTools[tool]
+                                ? 'bg-emerald-500/20 border-emerald-400/40 text-emerald-200'
+                                : 'bg-slate-800/60 border-slate-600 text-slate-300'
+                            }`}
+                          >
+                            {tool}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-sm text-slate-300">Goals</label>
+                      <textarea
+                        rows={4}
+                        value={objectives}
+                        onChange={(event) => setObjectives(event.target.value)}
+                        placeholder="One goal per line"
+                        className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
+                      />
+                    </div>
+
+                    {manualError && <p className="text-sm text-red-300">{manualError}</p>}
+
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        className="px-4 py-2 text-sm rounded-lg border border-slate-600 text-slate-200 hover:bg-slate-700/60"
+                        onClick={handleClose}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSubmitManual}
+                        disabled={manualSubmitting || !name.trim()}
+                        className="px-4 py-2 text-sm rounded-lg border border-emerald-500/40 bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30 disabled:opacity-50"
+                      >
+                        {manualSubmitting ? 'Creating…' : 'Create Agent'}
+                      </button>
                     </div>
                   </div>
-                  <div>
-                    <label className="block text-sm text-slate-300">Goals</label>
-                    <textarea
-                      rows={4}
-                      value={objectives}
-                      onChange={(event) => setObjectives(event.target.value)}
-                      placeholder="One goal per line"
-                      className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-white"
-                    />
-                  </div>
-                </div>
-
-                {error && <p className="mt-4 text-sm text-red-300">{error}</p>}
-
-                <div className="mt-6 flex justify-end gap-2">
-                  <button
-                    type="button"
-                    className="px-4 py-2 text-sm rounded-lg border border-slate-600 text-slate-200 hover:bg-slate-700/60"
-                    onClick={onClose}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSubmit}
-                    disabled={submitting}
-                    className="px-4 py-2 text-sm rounded-lg border border-emerald-500/40 bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30 disabled:opacity-50"
-                  >
-                    {submitting ? 'Creating…' : 'Create Agent'}
-                  </button>
-                </div>
+                )}
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,6 +10,52 @@ export interface Agent {
   updated_at: string;
 }
 
+export interface SandboxLaunchLog {
+  timestamp: string;
+  message: string;
+}
+
+export interface SpawnResult {
+  sandboxId: string;
+  logs: SandboxLaunchLog[];
+}
+
+export interface SecurityProfile {
+  sandbox: boolean;
+  network: {
+    allowInternet: boolean;
+    domainsAllowed: string[];
+  };
+  filesystem: {
+    read: string[];
+    write: string[];
+  };
+  permissions: string[];
+  executionTimeout: number;
+}
+
+export interface GeneratedAgentSpec {
+  name: string;
+  description: string;
+  goals: string[];
+  capabilities: {
+    tools: string[];
+    memory: boolean;
+    autonomy_level: 'manual' | 'semi' | 'autonomous';
+    execution_interval: string;
+  };
+  model: string;
+  securityProfile: SecurityProfile;
+  creator: string;
+  created_at: string;
+}
+
+export interface BuildAgentResult {
+  spec: GeneratedAgentSpec;
+  savedAgent?: Agent;
+  spawnResult?: SpawnResult | null;
+}
+
 export interface Task {
   id: string;
   agent_id: string;

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json tsconfig.json ./
 RUN npm install --production=false
 COPY src ./src
+COPY scripts ./scripts
 RUN npm run build
 
 FROM node:20-alpine

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node scripts/copyStaticAssets.mjs",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/server/scripts/copyStaticAssets.mjs
+++ b/server/scripts/copyStaticAssets.mjs
@@ -1,0 +1,22 @@
+import { mkdir, copyFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function copyPermissionsFile() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const source = path.join(projectRoot, 'src', 'config', 'permissions.yaml');
+  const destinationDir = path.join(projectRoot, 'dist', 'config');
+  const destination = path.join(destinationDir, 'permissions.yaml');
+
+  await mkdir(destinationDir, { recursive: true });
+  await copyFile(source, destination);
+  console.log(`Copied permissions.yaml to ${destination}`);
+}
+
+copyPermissionsFile().catch((error) => {
+  console.error('Failed to copy static assets', error);
+  process.exit(1);
+});

--- a/server/src/config/permissionLoader.ts
+++ b/server/src/config/permissionLoader.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+export type PermissionMap = Record<string, string[]>;
+
+let cachedPermissions: PermissionMap | null = null;
+
+function parseSimpleYaml(content: string): PermissionMap {
+  const lines = content.split(/\r?\n/);
+  const result: PermissionMap = {};
+  let currentKey: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line || line.trim().startsWith('#')) {
+      continue;
+    }
+
+    if (!line.startsWith('-') && line.includes(':')) {
+      const [key] = line.split(':');
+      currentKey = key.trim();
+      if (!result[currentKey]) {
+        result[currentKey] = [];
+      }
+      continue;
+    }
+
+    if (line.trimStart().startsWith('-')) {
+      if (!currentKey) {
+        continue;
+      }
+      const value = line.replace(/^-\s*/, '').trim();
+      if (value) {
+        result[currentKey].push(value);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function loadPermissionMap(): PermissionMap {
+  if (cachedPermissions) {
+    return cachedPermissions;
+  }
+
+  const filePath = fileURLToPath(new URL('./permissions.yaml', import.meta.url));
+  const content = readFileSync(filePath, 'utf-8');
+  cachedPermissions = parseSimpleYaml(content);
+  return cachedPermissions;
+}

--- a/server/src/config/permissions.yaml
+++ b/server/src/config/permissions.yaml
@@ -1,0 +1,27 @@
+browser:
+  - fetch
+  - analyze
+  - summarize
+api:
+  - fetch
+  - analyze
+email:
+  - communicate
+  - notify
+scheduler:
+  - schedule
+  - automate
+notifier:
+  - notify
+  - alert
+code_executor:
+  - run_code
+  - analyze
+memory:
+  - remember
+  - retrieve
+summarizer:
+  - summarize
+llm:
+  - analyze
+  - synthesize

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { initDb } from './db.js';
 import agentsRoute from './routes/agents.js';
 import tasksRoute from './routes/tasks.js';
 import commandsRoute from './routes/commands.js';
+import agentBuilderRoute from './routes/agentBuilder.js';
 import { coordinator } from './core/Coordinator.js';
 
 async function bootstrap() {
@@ -21,6 +22,7 @@ async function bootstrap() {
   app.use('/agents', agentsRoute);
   app.use('/tasks', tasksRoute);
   app.use('/commands', commandsRoute);
+  app.use('/agent-builder', agentBuilderRoute);
 
   app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
     console.error(err);

--- a/server/src/routes/agentBuilder.ts
+++ b/server/src/routes/agentBuilder.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { naturalLanguageAgentBuilder } from '../services/NaturalLanguageAgentBuilder.js';
+
+const router = Router();
+
+const buildSchema = z.object({
+  promptText: z.string().min(1),
+  options: z
+    .object({
+      persist: z.boolean().optional(),
+      spawn: z.boolean().optional(),
+      creator: z.string().optional()
+    })
+    .optional()
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = buildSchema.parse(req.body);
+    const result = await naturalLanguageAgentBuilder.buildAgent(payload.promptText, payload.options ?? {});
+    res.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/spec', async (req, res, next) => {
+  try {
+    const payload = buildSchema.pick({ promptText: true, options: true }).parse(req.body);
+    const creator = payload.options?.creator ?? 'anonymous';
+    const spec = naturalLanguageAgentBuilder.buildSpec(payload.promptText, creator);
+    res.json({ spec });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/services/AgentRunner.ts
+++ b/server/src/services/AgentRunner.ts
@@ -1,0 +1,16 @@
+import type { AgentSpec } from './NaturalLanguageAgentBuilder.js';
+
+export interface RunnerLog {
+  timestamp: string;
+  message: string;
+}
+
+export class AgentRunner {
+  launch(spec: AgentSpec): RunnerLog {
+    const timestamp = new Date().toISOString();
+    return {
+      timestamp,
+      message: `Agent "${spec.name}" scheduled for execution inside sandbox with timeout ${spec.securityProfile.executionTimeout}s.`
+    };
+  }
+}

--- a/server/src/services/NaturalLanguageAgentBuilder.ts
+++ b/server/src/services/NaturalLanguageAgentBuilder.ts
@@ -1,0 +1,294 @@
+import { loadPermissionMap } from '../config/permissionLoader.js';
+import { SandboxManager, type SpawnResult } from './SandboxManager.js';
+
+const permissionMap = loadPermissionMap();
+
+export interface AgentSpec {
+  name: string;
+  description: string;
+  goals: string[];
+  capabilities: {
+    tools: string[];
+    memory: boolean;
+    autonomy_level: 'manual' | 'semi' | 'autonomous';
+    execution_interval: string;
+  };
+  model: string;
+  securityProfile: {
+    sandbox: boolean;
+    network: {
+      allowInternet: boolean;
+      domainsAllowed: string[];
+    };
+    filesystem: {
+      read: string[];
+      write: string[];
+    };
+    permissions: string[];
+    executionTimeout: number;
+  };
+  creator: string;
+  created_at: string;
+}
+
+export interface BuildAgentOptions {
+  persist?: boolean;
+  spawn?: boolean;
+  creator?: string;
+}
+
+export interface BuildAgentResult {
+  spec: AgentSpec;
+  savedAgent?: unknown;
+  spawnResult?: SpawnResult | null;
+}
+
+const TOOL_KEYWORDS: Record<string, RegExp[]> = {
+  browser: [/(\b|\s)(fetch|scrape|browse|monitor|read|check|track|scan|research)(\b|\s)/i, /news/i, /web/i],
+  api: [/api/i, /endpoint/i, /integrate/i],
+  email: [/email/i, /mail\b/i, /inbox/i, /send\s+me/i],
+  scheduler: [/daily/i, /weekly/i, /every\s+(morning|day|week|hour|month)/i, /schedule/i],
+  notifier: [/notify/i, /alert/i, /remind/i],
+  summarizer: [/summary/i, /summari[sz]e/i, /digest/i],
+  code_executor: [/run\s+code/i, /execute\s+script/i, /simulation/i],
+  memory: [/remember/i, /log/i, /history/i],
+  llm: [/write/i, /draft/i, /analy[sz]e/i, /generate/i]
+};
+
+const DOMAIN_MAPPINGS: { keywords: RegExp[]; domains: string[] }[] = [
+  { keywords: [/crypto/i, /bitcoin/i, /ethereum/i, /token/i], domains: ['api.coingecko.com'] },
+  { keywords: [/stock/i, /market/i, /finance/i, /equity/i], domains: ['finnhub.io', 'alphavantage.co'] },
+  { keywords: [/news/i, /headline/i, /press/i], domains: ['newsapi.org'] },
+  { keywords: [/weather/i, /forecast/i, /temperature/i], domains: ['api.openweathermap.org'] },
+  { keywords: [/github/i, /repository/i], domains: ['api.github.com'] },
+  { keywords: [/tweet/i, /twitter/i, /x\.com/i], domains: ['api.twitter.com'] }
+];
+
+const INTERNET_CUES = [/internet/i, /online/i, /fetch/i, /browser/i, /api/i, /scrape/i, /news/i, /monitor/i];
+
+const SUMMARY_CUES = [/summary/i, /summari[sz]e/i, /digest/i];
+
+function dedupe<T>(items: T[]): T[] {
+  return Array.from(new Set(items));
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function inferName(prompt: string): string {
+  const segments = prompt
+    .replace(/[.!?]/g, '')
+    .split(/(?:make|build|create|need|want|design|develop)\s+me\s+an?\s+agent\s+that/i);
+  const relevant = segments.length > 1 ? segments[1] : prompt;
+  const keywords = ['news', 'crypto', 'research', 'email', 'weather', 'insight', 'market'];
+  for (const keyword of keywords) {
+    if (new RegExp(keyword, 'i').test(prompt)) {
+      return titleCase(`${keyword} assistant`).replace(/\bAssistant\b/i, 'Assistant');
+    }
+  }
+  const truncated = relevant.trim().split(/[,;:.]/)[0];
+  const words = truncated.split(/\s+/).slice(0, 3);
+  if (words.length > 0) {
+    return titleCase(`${words.join(' ')} Agent`).trim();
+  }
+  return 'Adaptive Agent';
+}
+
+function summarizePrompt(prompt: string): string {
+  const trimmed = prompt.trim();
+  if (trimmed.length <= 140) {
+    return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+  }
+  return `${trimmed.slice(0, 137)}...`;
+}
+
+function extractGoals(prompt: string): string[] {
+  const normalized = prompt.replace(/[.!?]/g, '.');
+  const parts = normalized
+    .split(/\b(?:and then|then|and|so that|to)\b/i)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const goals = new Set<string>();
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (/(fetch|get|collect|pull)/.test(lower) && /(news|data|updates|prices|information)/.test(lower)) {
+      goals.add('Fetch relevant data from trusted sources');
+    }
+    if (/(summari|digest|condense|report)/.test(lower)) {
+      goals.add('Summarize findings into concise reports');
+    }
+    if (/(email|send|notify|alert)/.test(lower)) {
+      goals.add('Deliver notifications or summaries to stakeholders');
+    }
+    if (/(analy|insight|interpret)/.test(lower)) {
+      goals.add('Analyze data to surface actionable insights');
+    }
+    if (/(monitor|track|watch)/.test(lower)) {
+      goals.add('Continuously monitor sources for new information');
+    }
+    if (/(schedule|daily|weekly|morning|evening)/.test(lower)) {
+      goals.add('Run on a recurring schedule without manual intervention');
+    }
+  }
+
+  if (goals.size === 0) {
+    goals.add(prompt.trim());
+  }
+
+  return Array.from(goals);
+}
+
+function detectTools(prompt: string): string[] {
+  const tools: string[] = [];
+  for (const [tool, patterns] of Object.entries(TOOL_KEYWORDS)) {
+    if (patterns.some((pattern) => pattern.test(prompt))) {
+      tools.push(tool);
+    }
+  }
+  if (!tools.includes('llm')) {
+    tools.push('llm');
+  }
+  if (SUMMARY_CUES.some((pattern) => pattern.test(prompt)) && !tools.includes('summarizer')) {
+    tools.push('summarizer');
+  }
+  return dedupe(tools);
+}
+
+function detectAutonomy(prompt: string): 'manual' | 'semi' | 'autonomous' {
+  if (/(automatic|automatically|without\s+me|hands?-?free|self\b)/i.test(prompt)) {
+    return 'autonomous';
+  }
+  if (/(assist|help|support)/i.test(prompt)) {
+    return 'semi';
+  }
+  return 'semi';
+}
+
+function detectInterval(prompt: string): string {
+  if (/every\s+hour|hourly/i.test(prompt)) {
+    return 'hourly';
+  }
+  if (/daily|every\s+(day|morning|evening)/i.test(prompt)) {
+    return 'daily';
+  }
+  if (/weekly|every\s+week/i.test(prompt)) {
+    return 'weekly';
+  }
+  if (/monthly|every\s+month/i.test(prompt)) {
+    return 'monthly';
+  }
+  if (/real\s*-?time|continuous|ongoing/i.test(prompt)) {
+    return 'continuous';
+  }
+  return 'on_demand';
+}
+
+function detectDomains(prompt: string): string[] {
+  const domains = new Set<string>();
+  for (const mapping of DOMAIN_MAPPINGS) {
+    if (mapping.keywords.some((regex) => regex.test(prompt))) {
+      mapping.domains.forEach((domain) => domains.add(domain));
+    }
+  }
+  if (domains.size === 0 && INTERNET_CUES.some((regex) => regex.test(prompt))) {
+    domains.add('newsapi.org');
+  }
+  return Array.from(domains);
+}
+
+function detectPermissions(tools: string[], prompt: string): string[] {
+  const permissions = new Set<string>();
+  tools.forEach((tool) => {
+    const entries = permissionMap[tool];
+    if (entries) {
+      entries.forEach((permission) => permissions.add(permission));
+    }
+  });
+  if (SUMMARY_CUES.some((pattern) => pattern.test(prompt))) {
+    permissions.add('summarize');
+  }
+  if (permissions.size === 0) {
+    ['analyze'].forEach((permission) => permissions.add(permission));
+  }
+  return Array.from(permissions);
+}
+
+function detectMemory(prompt: string): boolean {
+  return /(remember|history|log|past|previous|context|record)/i.test(prompt) || SUMMARY_CUES.some((pattern) => pattern.test(prompt));
+}
+
+function shouldAllowInternet(prompt: string): boolean {
+  return INTERNET_CUES.some((pattern) => pattern.test(prompt));
+}
+
+export class NaturalLanguageAgentBuilder {
+  constructor(private readonly sandboxManager = new SandboxManager()) {}
+
+  buildSpec(promptText: string, creator = 'anonymous'): AgentSpec {
+    const name = inferName(promptText);
+    const description = summarizePrompt(promptText);
+    const goals = extractGoals(promptText);
+    const tools = detectTools(promptText);
+    const allowInternet = shouldAllowInternet(promptText);
+    const domains = allowInternet ? detectDomains(promptText) : [];
+    const permissions = detectPermissions(tools, promptText);
+    const execution_interval = detectInterval(promptText);
+    const memory = detectMemory(promptText);
+    const autonomy_level = detectAutonomy(promptText);
+
+    const spec: AgentSpec = {
+      name,
+      description,
+      goals,
+      capabilities: {
+        tools,
+        memory,
+        autonomy_level,
+        execution_interval
+      },
+      model: 'gpt-5',
+      securityProfile: {
+        sandbox: true,
+        network: {
+          allowInternet,
+          domainsAllowed: allowInternet ? domains : []
+        },
+        filesystem: {
+          read: ['workspace/tmp'],
+          write: ['workspace/output']
+        },
+        permissions,
+        executionTimeout: 300
+      },
+      creator,
+      created_at: new Date().toISOString()
+    };
+
+    return spec;
+  }
+
+  async buildAgent(promptText: string, options: BuildAgentOptions = {}): Promise<BuildAgentResult> {
+    const creator = options.creator ?? 'anonymous';
+    const spec = this.buildSpec(promptText, creator);
+
+    let savedAgent: unknown | undefined;
+    if (options.persist ?? true) {
+      savedAgent = await this.sandboxManager.saveAgent(spec);
+    }
+
+    let spawnResult: SpawnResult | null = null;
+    if (options.spawn) {
+      spawnResult = await this.sandboxManager.spawnAgent(spec);
+    }
+
+    return { spec, savedAgent, spawnResult };
+  }
+}
+
+export const naturalLanguageAgentBuilder = new NaturalLanguageAgentBuilder();

--- a/server/src/services/NetworkProxy.ts
+++ b/server/src/services/NetworkProxy.ts
@@ -1,0 +1,27 @@
+export interface NetworkSecurityConfig {
+  allowInternet: boolean;
+  domainsAllowed: string[];
+}
+
+export interface NetworkProxyLog {
+  timestamp: string;
+  message: string;
+}
+
+export class NetworkProxy {
+  configure(config: NetworkSecurityConfig): NetworkProxyLog {
+    const timestamp = new Date().toISOString();
+    if (!config.allowInternet) {
+      return {
+        timestamp,
+        message: 'Network proxy configured for offline execution. External requests are blocked.'
+      };
+    }
+
+    const domains = config.domainsAllowed.length > 0 ? config.domainsAllowed.join(', ') : 'no domains specified';
+    return {
+      timestamp,
+      message: `Network proxy enabled with internet access limited to: ${domains}.`
+    };
+  }
+}

--- a/server/src/services/SandboxManager.ts
+++ b/server/src/services/SandboxManager.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'crypto';
+import { agentManager } from '../core/AgentManager.js';
+import type { AgentSpec } from './NaturalLanguageAgentBuilder.js';
+import { AgentRunner } from './AgentRunner.js';
+import { NetworkProxy, type NetworkProxyLog } from './NetworkProxy.js';
+
+export interface SandboxLaunchLog {
+  timestamp: string;
+  message: string;
+}
+
+export interface SpawnResult {
+  sandboxId: string;
+  logs: SandboxLaunchLog[];
+}
+
+export class SandboxManager {
+  constructor(
+    private readonly agentRunner = new AgentRunner(),
+    private readonly networkProxy = new NetworkProxy()
+  ) {}
+
+  async saveAgent(agentSpec: AgentSpec) {
+    const record = await agentManager.createAgent({
+      name: agentSpec.name,
+      role: agentSpec.description,
+      tools: agentSpec.capabilities.tools.reduce<Record<string, boolean>>((acc, tool) => {
+        acc[tool] = true;
+        return acc;
+      }, {}),
+      objectives: agentSpec.goals,
+      memory_context: agentSpec.capabilities.memory ? 'Long-term memory enabled' : ''
+    });
+
+    return record;
+  }
+
+  async spawnAgent(agentSpec: AgentSpec): Promise<SpawnResult> {
+    const sandboxId = randomUUID();
+    const logs: SandboxLaunchLog[] = [];
+
+    const networkLog: NetworkProxyLog = this.networkProxy.configure(agentSpec.securityProfile.network);
+    logs.push(networkLog);
+
+    const runnerLog = this.agentRunner.launch(agentSpec);
+    logs.push(runnerLog);
+
+    logs.push({
+      timestamp: new Date().toISOString(),
+      message: `Sandbox ${sandboxId} initialized with filesystem policy read: ${agentSpec.securityProfile.filesystem.read.join(', ') || 'none'}, write: ${agentSpec.securityProfile.filesystem.write.join(', ') || 'none'}.`
+    });
+
+    return { sandboxId, logs };
+  }
+}


### PR DESCRIPTION
## Summary
- copy the permissions.yaml config into the server dist folder during builds so the natural language agent builder can load its permission map at runtime
- extend the frontend API types and client to call the natural language builder endpoints and surface their structured results
- refresh the create agent modal with a natural language generation flow that previews the sandboxed spec while retaining manual configuration as an option
- ensure the server Docker image copies the build scripts so permissions assets are bundled during container builds

## Testing
- npm --prefix server run build

------
https://chatgpt.com/codex/tasks/task_e_68e6319f89e48326b9b2c7a42dd7c29f