### PR TITLE
Fix agent creation request failing in new UI

### DIFF
--- a/meta-agent-platform-ui/src/lib/api.ts
+++ b/meta-agent-platform-ui/src/lib/api.ts
@@ -11,13 +11,14 @@ import type {
 const API_BASE =
   import.meta.env.VITE_API_BASE_URL ?? (import.meta.env.DEV ? 'http://localhost:4000' : '');
 
-async function request<T>(path: string, options?: RequestInit): Promise<T> {
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const { headers, ...rest } = options;
   const response = await fetch(`${API_BASE}${path}`, {
     headers: {
       'Content-Type': 'application/json',
+      ...(headers ?? {}),
     },
-    credentials: 'include',
-    ...options,
+    ...rest,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- stop forcing credentials on every API call in the new UI client to avoid cross-origin fetch failures
- allow custom headers to be merged while keeping JSON defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6748467e48326bf882de5661638de